### PR TITLE
Fix: Update Iran checkout data source and parsing logic

### DIFF
--- a/ccif-iran-checkout.php
+++ b/ccif-iran-checkout.php
@@ -26,7 +26,7 @@ class CCIF_Iran_Checkout_Rebuild {
     }
 
     private function load_iran_data() {
-        $json_file = plugin_dir_path( __FILE__ ) . 'assets/data/iran-cities.json';
+        $json_file = plugin_dir_path( __FILE__ ) . 'assets/data/iran_data-2.json';
         if ( ! file_exists( $json_file ) ) return [ 'states' => [], 'cities' => [] ];
         $data = json_decode( file_get_contents( $json_file ), true );
         $states = [];
@@ -34,7 +34,7 @@ class CCIF_Iran_Checkout_Rebuild {
         foreach ( $data as $province ) {
             $slug = sanitize_title( $province['name'] );
             $states[ $slug ] = $province['name'];
-            $cities[ $slug ] = array_column( $province['cities'], 'name' );
+            $cities[ $slug ] = $province['cities'];
         }
         return [ 'states' => $states, 'cities' => $cities ];
     }


### PR DESCRIPTION
I changed the data source for provinces and cities from the incomplete 'iran-cities.json' to the more comprehensive 'iran_data-2.json'.

I also modified the 'load_iran_data' function in 'ccif-iran-checkout.php' to correctly handle the new data structure, where cities are a simple array of strings instead of an array of objects.

This resolves the issue where the city dropdown was not being populated after you selected a province.